### PR TITLE
feat: 新增body参数越权

### DIFF
--- a/src/main/java/com/chave/bean/FuzzRequestItem.java
+++ b/src/main/java/com/chave/bean/FuzzRequestItem.java
@@ -1,6 +1,8 @@
 package com.chave.bean;
 
 import burp.api.montoya.http.message.HttpRequestResponse;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.http.message.responses.HttpResponse;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,7 +16,8 @@ public class FuzzRequestItem {
     private String responseCode;
     private String responseTime;
     private OriginRequestItem originRequestItem;
-    private HttpRequestResponse fuzzRequestResponse;
+    private HttpRequest fuzzRequest;
+    private HttpResponse fuzzResponse;
 
     public FuzzRequestItem(String param, String payload, String responseLength, String responseLengthChange, String responseCode, String responseTime, OriginRequestItem originRequestItem) {
         this.param = param;

--- a/src/main/java/com/chave/config/UserConfig.java
+++ b/src/main/java/com/chave/config/UserConfig.java
@@ -15,6 +15,7 @@ public class UserConfig {
     public static Boolean APPEND_MOD = Boolean.FALSE;
     public static Boolean PARAM_URL_ENCODE = Boolean.FALSE;
     public static Boolean UNAUTH = Boolean.FALSE;
+    public static Boolean DATAAUTH = Boolean.FALSE;
 
     public static SearchScope SEARCH_SCOPE;
 

--- a/src/main/java/com/chave/service/AutoFuzzService.java
+++ b/src/main/java/com/chave/service/AutoFuzzService.java
@@ -298,8 +298,14 @@ public class AutoFuzzService {
         for (HttpRequest request : requestToBeSentList) {
             HttpRequestResponse httpRequestResponse = Main.API.http().sendRequest(request);
             FuzzRequestItem fuzzRequestItem = fuzzRequestItemArrayList.get(i);
-            fuzzRequestItem.setFuzzRequestResponse(httpRequestResponse);  // 与table数据关联
-
+            //如果是galaxy插件要加密的明文，直接将明文传到fuzzRequestItem中，而非明文。
+            if (request.hasHeader("X-Galaxy-Http-Hook")) {
+                fuzzRequestItem.setFuzzRequest(request);
+            } else {
+                // 默认设置
+                fuzzRequestItem.setFuzzRequest(httpRequestResponse.request());  // 与table数据关联
+            }
+            fuzzRequestItem.setFuzzResponse(httpRequestResponse.response());  // 与table数据关联
             // 获取返回包长度信息
             String responseLength = httpRequestResponse.response().toString().length() + "";
             int lengthChange = httpRequestResponse.response().toString().length() - Integer.parseInt(fuzzRequestItem.getOriginRequestItem().getResponseLength());

--- a/src/main/java/com/chave/ui/MainUI.java
+++ b/src/main/java/com/chave/ui/MainUI.java
@@ -18,6 +18,7 @@ import java.awt.*;
 import java.awt.event.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -1110,8 +1111,8 @@ public class MainUI {
             for (Map.Entry<Integer, OriginRequestItem> originRequestItemEntry : ORIGIN_REQUEST_TABLE_DATA.entrySet()) {
                 OriginRequestItem originRequestItem = originRequestItemEntry.getValue();
                 if (originRequestItem.equals(selectOriginRequestItem) && originRequestItem.getId().equals(id)) {
-                    String originRequestString = originRequestItem.getOriginRequest().toString();
-                    String originResponseString = originRequestItem.getOriginResponse().toString();
+                    String originRequestString = new String(originRequestItem.getOriginRequest().toByteArray().getBytes(), StandardCharsets.UTF_8);
+                    String originResponseString = new String(originRequestItem.getOriginResponse().toByteArray().getBytes(), StandardCharsets.UTF_8);
                     // 进行不区分大小写的比对originRequest
                     if (originRequestString.toLowerCase().contains(keyword.toLowerCase()) && searchScope.equals(SearchScope.REQUEST)) {
                         highlightMap.put(i, new ArrayList<>());
@@ -1123,8 +1124,8 @@ public class MainUI {
                     ArrayList<FuzzRequestItem> fuzzRequestArrayList = originRequestItem.getFuzzRequestArrayList();
                     int index = 0;
                     for (FuzzRequestItem fuzzRequestItem : fuzzRequestArrayList) {
-                        String fuzzRequestString = fuzzRequestItem.getFuzzRequestResponse().request().toString();
-                        String fuzzResponseString = fuzzRequestItem.getFuzzRequestResponse().response().toString();
+                        String fuzzRequestString = new String(fuzzRequestItem.getFuzzRequestResponse().request().toByteArray().getBytes(), StandardCharsets.UTF_8);
+                        String fuzzResponseString = new String(fuzzRequestItem.getFuzzRequestResponse().response().toByteArray().getBytes(), StandardCharsets.UTF_8);
                         if (fuzzRequestString.toLowerCase().contains(keyword.toLowerCase()) && searchScope.equals(SearchScope.REQUEST)) {
                             if (highlightMap.containsKey(i)) {
                                 highlightMap.get(i).add(index);

--- a/src/main/java/com/chave/ui/MainUI.java
+++ b/src/main/java/com/chave/ui/MainUI.java
@@ -942,8 +942,8 @@ public class MainUI {
                     if (item.equals(tempItem) && item.getId().equals(id)) {
                         if (fuzzRow < item.getFuzzRequestArrayList().size()) {
                             FuzzRequestItem fuzzItem = item.getFuzzRequestArrayList().get(fuzzRow);
-                            requestEditor.setRequest(fuzzItem.getFuzzRequestResponse().request());
-                            responseEditor.setResponse(fuzzItem.getFuzzRequestResponse().response());
+                            requestEditor.setRequest(fuzzItem.getFuzzRequest());
+                            responseEditor.setResponse(fuzzItem.getFuzzResponse());
                         }
                         break;
                     }
@@ -1141,8 +1141,8 @@ public class MainUI {
                     ArrayList<FuzzRequestItem> fuzzRequestArrayList = originRequestItem.getFuzzRequestArrayList();
                     int index = 0;
                     for (FuzzRequestItem fuzzRequestItem : fuzzRequestArrayList) {
-                        String fuzzRequestString = new String(fuzzRequestItem.getFuzzRequestResponse().request().toByteArray().getBytes(), StandardCharsets.UTF_8);
-                        String fuzzResponseString = new String(fuzzRequestItem.getFuzzRequestResponse().response().toByteArray().getBytes(), StandardCharsets.UTF_8);
+                        String fuzzRequestString = new String(fuzzRequestItem.getFuzzRequest().toByteArray().getBytes(), StandardCharsets.UTF_8);
+                        String fuzzResponseString = new String(fuzzRequestItem.getFuzzResponse().toByteArray().getBytes(), StandardCharsets.UTF_8);
                         if (fuzzRequestString.toLowerCase().contains(keyword.toLowerCase()) && searchScope.equals(SearchScope.REQUEST)) {
                             if (highlightMap.containsKey(i)) {
                                 highlightMap.get(i).add(index);

--- a/src/main/java/com/chave/ui/MainUI.java
+++ b/src/main/java/com/chave/ui/MainUI.java
@@ -81,6 +81,7 @@ public class MainUI {
     private JCheckBox emptyParamCheckBox;
     private JCheckBox paramURLEncodeCheckBox;
     private JCheckBox unauthCheckBox;
+    private JCheckBox dataAuthCheckBox;
     private JCheckBox appendModCheckBox;
     private JLabel basicTitleLabel;
     private JLabel domainTitleLabel;
@@ -136,6 +137,7 @@ public class MainUI {
         langSupportComponent.add("editAuthHeaderButton");
         langSupportComponent.add("removeAuthHeaderButton");
         langSupportComponent.add("unauthCheckBox");
+        langSupportComponent.add("dataAuthCheckBox");
         langSupportComponent.add("searchButton");
         langSupportComponent.add("cleanSearchResultButton");
     }
@@ -177,6 +179,7 @@ public class MainUI {
         paramURLEncodeCheckBox = new JCheckBox();
         includeSubDomainCheckBox = new JCheckBox();
         unauthCheckBox = new JCheckBox();
+        dataAuthCheckBox = new JCheckBox();
         appendModCheckBox = new JCheckBox();
         addDomainButton = new JButton();
         editDomainButton = new JButton();
@@ -453,6 +456,8 @@ public class MainUI {
         authHeaderOperatePanel.setLayout(authHeaderOperateLayout);
         // 设置未授权访问勾选情况
         unauthCheckBox.setSelected(UserConfig.UNAUTH);
+        // 设置dataAuth勾选情况
+        dataAuthCheckBox.setSelected(UserConfig.DATAAUTH);
         authHeaderOperatePanel.add(addAuthHeaderButton, Component.CENTER_ALIGNMENT);
         authHeaderOperatePanel.add(Box.createVerticalStrut(10));
         authHeaderOperatePanel.add(editAuthHeaderButton, Component.CENTER_ALIGNMENT);
@@ -460,6 +465,7 @@ public class MainUI {
         authHeaderOperatePanel.add(removeAuthHeaderButton, Component.CENTER_ALIGNMENT);
         authHeaderOperatePanel.add(Box.createVerticalStrut(10));
         authHeaderOperatePanel.add(unauthCheckBox, Component.CENTER_ALIGNMENT);
+        authHeaderOperatePanel.add(dataAuthCheckBox, Component.CENTER_ALIGNMENT);
         authHeaderMainPanel.add(Box.createHorizontalStrut(5));
         authHeaderMainPanel.add(authHeaderOperatePanel);
         // 初始化header表格
@@ -845,7 +851,18 @@ public class MainUI {
                 YamlUtil.exportToYaml();
             }
         });
-
+        // 包含子域名复选框监听器
+        dataAuthCheckBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if (e.getStateChange() == ItemEvent.SELECTED) {
+                    UserConfig.DATAAUTH = Boolean.TRUE;
+                } else if (e.getStateChange() == ItemEvent.DESELECTED) {
+                    UserConfig.DATAAUTH = Boolean.FALSE;
+                }
+                YamlUtil.exportToYaml();
+            }
+        });
         // 查找作用域下拉框监听器
         searchScopeComboBox.addActionListener(new ActionListener() {
             @Override

--- a/src/main/java/com/chave/utils/YamlUtil.java
+++ b/src/main/java/com/chave/utils/YamlUtil.java
@@ -46,6 +46,8 @@ public class YamlUtil {
                 UserConfig.APPEND_MOD = (Boolean) payloadSetting.get("append_mod");
                 UserConfig.PARAM_URL_ENCODE = (Boolean) payloadSetting.get("param_url_encode");
                 UserConfig.UNAUTH = (Boolean) authHeaderSetting.get("unauth");
+                Object dataAuthValue = authHeaderSetting.get("dataAuth");
+                UserConfig.DATAAUTH = (dataAuthValue instanceof Boolean) ? (Boolean) dataAuthValue : false;
 
 
                 // 加载payload
@@ -121,6 +123,7 @@ public class YamlUtil {
         payloadSetting.put("append_mod", UserConfig.APPEND_MOD);
         payloadSetting.put("param_url_encode", UserConfig.PARAM_URL_ENCODE);
         authHeaderSetting.put("unauth", UserConfig.UNAUTH);
+        authHeaderSetting.put("dataAuth", UserConfig.DATAAUTH);
         configMap.put("basic_setting", basicSetting);
         configMap.put("domain_setting", domainSetting);
         configMap.put("payload_setting", payloadSetting);

--- a/src/main/resources/lang_en_US.properties
+++ b/src/main/resources/lang_en_US.properties
@@ -23,6 +23,7 @@ addAuthHeaderButton.text=Add
 editAuthHeaderButton.text=Edit
 removeAuthHeaderButton.text=Remove
 unauthCheckBox.text=UnAuth          
+dataAuthCheckBox.text=BrokenAccessControl
 searchButton.text=Search
 cleanSearchResultButton.text=CleanSearchResult
 addDomainTitle.text=Add Domain

--- a/src/main/resources/lang_zh_CN.properties
+++ b/src/main/resources/lang_zh_CN.properties
@@ -23,6 +23,7 @@ addAuthHeaderButton.text=添加
 editAuthHeaderButton.text=编辑
 removeAuthHeaderButton.text=删除
 unauthCheckBox.text=未授权访问
+dataAuthCheckBox.text=请求参数越权
 searchButton.text=查找
 cleanSearchResultButton.text=清空查找记录
 addDomainTitle.text=添加域名


### PR DESCRIPTION
根据Auth里设置的请求参数，检测url、body、json里的参数进行替换越权或置空未授权，并添加勾选框
这个功能可有可无，佬选择性更新就行
![微信截图_20250602183804](https://github.com/user-attachments/assets/aeaa6728-5328-43f3-94d3-ffe5c9dbee23)
![微信图片_20250602183618](https://github.com/user-attachments/assets/2fa433bb-cf63-4fa6-9078-48617d479a6e)


优化：联动galaxy插件
原请求包：
![微信截图_20250603130500](https://github.com/user-attachments/assets/fc133d82-0afe-4f3e-b953-7094123df603)
明文包右键到AutoFuzz后显示的请求包
![微信截图_20250604113637](https://github.com/user-attachments/assets/e3e0e804-f59e-47dd-af43-0aaf58e6560e)
